### PR TITLE
Removing 'json' filter from template.

### DIFF
--- a/settingsjs/templates/settingsjs/settings.js
+++ b/settingsjs/templates/settingsjs/settings.js
@@ -1,5 +1,5 @@
 (function (window) {
-    var settings = {{ settings|json }}; 
+    var settings = {{ jsonsettings|safe }};
     S = function () { }
     S.get = function (key) { return settings[key]; }
     S.set = function (key, val) { return settings[key] = val; }

--- a/settingsjs/views.py
+++ b/settingsjs/views.py
@@ -2,6 +2,8 @@ from django.conf import settings
 from django.template import RequestContext
 from django.shortcuts import render_to_response
 
+import json
+
 from . import signals
 
 
@@ -19,4 +21,5 @@ def settings_js(request, extra_context=None):
     signals.collect_settings.send(sender=settings_js,
                             jssettings=context['settings'], request=request)
 
+    context['jsonsettings'] = json.dumps(context['settings'])
     return render_to_response('settingsjs/settings.js', context, mimetype=mimetype)


### PR DESCRIPTION
'json' filter in the template replaced with json.dumps in the view
