### PR TITLE
Invalid filter: 'json'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# django-settingsjs changelog.
+
+
+## v0.1.3
+
+Update the `settings_js` view to include a `json` encoded version of the settings in the template content 
+Removes the dependency on the `json` filter from `django-incuna`.
+
+## v0.1.2
+
+The `request` is now passed to `collect_settings` listeners.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## v0.1.3
 
-Update the `settings_js` view to include a `json` encoded version of the settings in the template content 
+Update the `settings_js` view to include a `json` encoded version of the settings in the template content.
 Removes the dependency on the `json` filter from `django-incuna`.
 
 ## v0.1.2

--- a/settingsjs/__init__.py
+++ b/settingsjs/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (0, 1, 2)
+__version__ = (0, 1, 3)
 
 
 def get_version():

--- a/settingsjs/templates/settingsjs/settings.js
+++ b/settingsjs/templates/settingsjs/settings.js
@@ -1,5 +1,5 @@
 (function (window) {
-    var settings = {{ settings|json }}; 
+    var settings = {{ jssettings|safe }}; 
     S = function () { }
     S.get = function (key) { return settings[key]; }
     S.set = function (key, val) { return settings[key] = val; }

--- a/settingsjs/views.py
+++ b/settingsjs/views.py
@@ -1,3 +1,5 @@
+import json
+
 from django.conf import settings
 from django.template import RequestContext
 from django.shortcuts import render_to_response
@@ -9,14 +11,22 @@ def settings_js(request, extra_context=None):
     mimetype = 'text/javascript'
 
     context = RequestContext(request)
-    if extra_context != None:
+    if extra_context is not None:
         context.update(extra_context)
 
-    context['settings'] = getattr(context, 'settings', {})
+    jssettings = getattr(context, 'settings', {})
     if hasattr(settings, 'SETTINGS_JS'):
-        context['settings'].update(settings.SETTINGS_JS)
+        jssettings.update(settings.SETTINGS_JS)
 
-    signals.collect_settings.send(sender=settings_js,
-                            jssettings=context['settings'], request=request)
+    signals.collect_settings.send(
+        sender=settings_js,
+        jssettings=jssettings,
+        request=request
+    )
+
+    context.update({
+        'settings': jssettings,
+        'jssettings': json.dumps(jssettings)
+    })
 
     return render_to_response('settingsjs/settings.js', context, mimetype=mimetype)


### PR DESCRIPTION
@maxpeterson the template uses the `json` filter which is defined in `django-incuna` making this unusable without it. Or am I missing something?

https://github.com/incuna/django-settingsjs/blob/master/settingsjs/templates/settingsjs/settings.js#L2
